### PR TITLE
feat: :memo: send web vitals events to analytic

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head'
 import Footer from './Footer'
 import Header from './Header'
 
-function Layout({ children }: React.PropsWithChildren) {
+const Layout = ({ children }: React.PropsWithChildren) => {
   return (
     <>
       <Head>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mecrano-portfolio",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://www.edwinobando.com",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -17,7 +18,8 @@
     "next": "12.2.5",
     "next-intl": "^2.7.4",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "web-vitals": "^3.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,12 @@
-import type { AppProps } from 'next/app'
+import type { AppProps, NextWebVitalsMetric } from 'next/app'
 import { NextIntlProvider } from 'next-intl'
 
 import Layout from 'components/layout'
 import GA from 'components/GA'
+import { event } from 'lib/gtag'
 import 'styles/globals.css'
 
-function MyApp({ Component, pageProps }: AppProps) {
+const MyApp = ({ Component, pageProps }: AppProps) => {
   return (
     <NextIntlProvider
       formats={{
@@ -27,6 +28,17 @@ function MyApp({ Component, pageProps }: AppProps) {
       </Layout>
     </NextIntlProvider>
   )
+}
+
+export const reportWebVitals = ({ id, name, label, value }: NextWebVitalsMetric) => {
+  if (typeof window !== 'undefined' && window?.gtag) {
+    event({
+      action: name,
+      category: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
+      label: id,
+      value,
+    })
+  }
 }
 
 export default MyApp

--- a/yarn.lock
+++ b/yarn.lock
@@ -3219,6 +3219,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+web-vitals@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-3.0.0.tgz#db8a32fd62738a439343309336720ee5685ac71e"
+  integrity sha512-3Gh6rH5aetFYqfkl9V59KCvjj9vp9U2Tkaep9MO+xpAVg+JULmQfi5zEkcPLkE6iU8pNYVwdjHvIU8RFAchYyQ==
+
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"


### PR DESCRIPTION
#### What problem is this solving?

Send Web Vitals events to analytics to track them

#### How to test it?

1. Run `yarn dev`
2. Go to browser and run `dataLayer` in the console section
3. You now should see the events fired to analitycs

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/26680887/187542723-d0911787-f0ff-420c-9272-d9d74b8217f9.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/3oKIPEqDGUULpEU0aQ/giphy.gif)
